### PR TITLE
Mobile responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import Main from "./components/Main";
 
 const App = () => {
   return (
-    <div className="flex h-screen">
+    <div className="flex flex-col h-screen sm:flex-row">
       <SideBar />
       <Main />
     </div>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -35,11 +35,11 @@ const Card = ({ content }) => {
   }, []);
 
   return (
-    <div className="m-card w-[22%] xl:w-[18%] hover:scale-105 transition duration-150 ease-out cursor-pointer">
+    <div className="m-card hover:scale-105 transition duration-150 ease-out cursor-pointer">
       <img
         src={img}
         alt="poster"
-        className="w-full h-[350px] xl:h-[400px] rounded-lg object-cover"
+        className="w-full aspect-[2/3] rounded-lg object-cover"
       />
       <div>
         <h3 className="mt-3 font-semibold text-lg leading-5 dark:text-zinc-300">

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -35,7 +35,7 @@ const Card = ({ content }) => {
   }, []);
 
   return (
-    <div className="m-card hover:scale-105 transition duration-150 ease-out cursor-pointer">
+    <article className="card hover:scale-105 transition duration-150 ease-out cursor-pointer">
       <img
         src={img}
         alt="poster"
@@ -59,7 +59,7 @@ const Card = ({ content }) => {
           </div>
         </div>
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/components/CardContainer.jsx
+++ b/src/components/CardContainer.jsx
@@ -32,7 +32,7 @@ const CardContainer = () => {
       :
       <div className='p-8 '>
       <h1 className='font-semibold text-3xl text-zinc-600 dark:text-zinc-400'>{itemQuery.slice(0,1).toUpperCase()+itemQuery.slice(1)}</h1>
-      <div className='wrapper_card flex flex-wrap gap-4 mt-12 justify-center items-center h-[70vh]'>
+      <div className='wrapper_card max-w-100 grid auto-rows-max grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] gap-5 mt-12 justify-start items-start h-[70vh]'>
         { moviesData.length > 0 && moviesData.map((item, index) => <Card content={item} key={index}/>)}
       </div>
     </div> 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,10 +9,10 @@ const Header = ({ isSideBar, setIsSideBar }) => {
   
 
   return (
-    <div className={`header py-6 flex ${isSideBar ? "justify-between" : "justify-center"} h-[80px] px-5 items-center bg-[#2448C7]`}>
-      {isSideBar && <img src={logo} alt="logo" className='w-20 pl-4'/>}
-      <span className='text-white cursor-pointer' onClick={toggleSideBar}> <FaAlignLeft size="1.2rem"/> </span>
-    </div>
+    <header className={`py-6 flex justify-between h-[80px] px-5 items-center bg-[#2448C7]`}>
+      <img src={logo} alt="logo" className='w-20 pl-4'/>
+      <span className='p-2 text-white cursor-pointer' onClick={toggleSideBar}> <FaAlignLeft size="1.4rem"/> </span>
+    </header>
   )
 }
 

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -4,10 +4,10 @@ import CardContainer from './CardContainer'
 
 const Main = () => {
   return (
-    <div className='flex-1 overflow-y-auto dark:bg-[#25292e]'>
+    <main className='flex-1 overflow-y-auto dark:bg-[#25292e]'>
       <SearchBar />
       <CardContainer />
-    </div>
+    </main>
   )
 }
 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -11,7 +11,10 @@ import { setMovies } from "../Store/Features/MoviesList";
 import { setLoading } from "../Store/Features/LoadingSlice";
 const SearchBar = () => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
   const inputRef = useRef(null);
   const dispatch = useDispatch();
   const searchMovie = (name) => {

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -45,7 +45,7 @@ const SearchBar = () => {
   };
   return (
     <div className="bg-[#3B54D4] py-7 px-9 flex gap-3 justify-between items-center">
-      <div className="flex gap-3 basis-1/2">
+      <search className="flex gap-3 basis-1/2">
         <span className="text-zinc-300">
           <CiSearch size="1.4rem" />
         </span>
@@ -59,7 +59,7 @@ const SearchBar = () => {
           onKeyDown={handleKeyDown}
           ref={inputRef}
         />
-      </div>
+      </search>
       <div>
         <span className="cursor-pointer text-zinc-300" onClick={toggleDarkMode}>
           {

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -17,7 +17,7 @@ const SideBar = () => {
   };
 
   return (
-    <div className={`w-[${isSideBar ? "max(12rem,15%)" : "4%"}] min-h[100vh] transition duration-150 ease-out`}>
+    <nav className={`w-[${isSideBar ? "max(12rem,15%)" : "4%"}] min-h[100vh] transition duration-150 ease-out`}>
       <Header isSideBar={isSideBar} setIsSideBar={setIsSideBar} />
       <div className="sidebar bg-[#1A1E23]">
         <div className="pt-16 text-white flex flex-col gap-2">
@@ -51,7 +51,7 @@ const SideBar = () => {
         </div>
         }
       </div>
-    </div>
+    </nav>
   );
 };
 

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -17,23 +17,23 @@ const SideBar = () => {
   };
 
   return (
-    <div className={`${isSideBar ? "xl:w-[15%]" : "xl:w-[4%]"} transition duration-150 ease-out w-[19%]`}>
+    <div className={`w-[${isSideBar ? "max(12rem,15%)" : "4%"}] transition duration-150 ease-out`}>
       <Header isSideBar={isSideBar} setIsSideBar={setIsSideBar} />
       <div className="sidebar bg-[#1A1E23]">
         <div className="pt-16 text-white flex flex-col gap-2">
-          <div className={`flex items-center gap-2 cursor-pointer hover:text-[#2448C7]  ${item === "trending" && "bg-black text-[#2448C7]"} p-4 px-6`} onClick={() => itemSearch("trending")}>
+          <div className={`flex items-center h-16 gap-2 cursor-pointer hover:text-[#2448C7]  ${item === "trending" && "bg-black text-[#2448C7]"} p-4 px-6`} onClick={() => itemSearch("trending")}>
             <IoHomeOutline size={ isSideBar ? `1.2rem` : `1.6rem`} />
             {isSideBar && <p className="text-lg">Trending</p>}
           </div>
-          <div className={`flex items-center gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7] ${item === "discover" && "bg-black text-[#2448C7]"}`} onClick={() => itemSearch("trending")}>
+          <div className={`flex items-center h-16 gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7] ${item === "discover" && "bg-black text-[#2448C7]"}`} onClick={() => itemSearch("trending")}>
             <IoWalletOutline size={ isSideBar ? `1.2rem` : `1.6rem`} />
             {isSideBar && <p className="text-lg">Discover</p>}
           </div>
-          <div className={`flex items-center gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7] ${item === "upcoming" && "bg-black text-[#2448C7]"}`} onClick={() => itemSearch("upcoming")}>
+          <div className={`flex items-center h-16 gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7] ${item === "upcoming" && "bg-black text-[#2448C7]"}`} onClick={() => itemSearch("upcoming")}>
             <FiCoffee size={ isSideBar ? `1.2rem` : `1.6rem`} />
             {isSideBar && <p className="text-lg">Upcoming</p>}
           </div>
-          <div className="flex items-center gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7]">
+          <div className="flex items-center h-16 gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7]">
             <FaRegHeart size={ isSideBar ? `1.2rem` : `1.6rem`} />
             {isSideBar && <p className="text-lg">Favorite</p>}
           </div>

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -17,7 +17,7 @@ const SideBar = () => {
   };
 
   return (
-    <div className={`w-[${isSideBar ? "max(12rem,15%)" : "4%"}] transition duration-150 ease-out`}>
+    <div className={`w-[${isSideBar ? "max(12rem,15%)" : "4%"}] min-h[100vh] transition duration-150 ease-out`}>
       <Header isSideBar={isSideBar} setIsSideBar={setIsSideBar} />
       <div className="sidebar bg-[#1A1E23]">
         <div className="pt-16 text-white flex flex-col gap-2">

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -17,9 +17,9 @@ const SideBar = () => {
   };
 
   return (
-    <nav className={`w-[${isSideBar ? "max(12rem,15%)" : "4%"}] min-h[100vh] transition duration-150 ease-out`}>
+    <nav className={`transition duration-150 ease-out`}>
       <Header isSideBar={isSideBar} setIsSideBar={setIsSideBar} />
-      <div className="sidebar bg-[#1A1E23]">
+      <div className="min-h[calc(100vh-80px)] bg-[#1A1E23]">
         <div className="pt-16 text-white flex flex-col gap-2">
           <div className={`flex items-center h-16 gap-2 cursor-pointer hover:text-[#2448C7]  ${item === "trending" && "bg-black text-[#2448C7]"} p-4 px-6`} onClick={() => itemSearch("trending")}>
             <IoHomeOutline size={ isSideBar ? `1.2rem` : `1.6rem`} />

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -19,28 +19,28 @@ const SideBar = () => {
   return (
     <nav className={`transition duration-150 ease-out`}>
       <Header isSideBar={isSideBar} setIsSideBar={setIsSideBar} />
-      <div className="min-h[calc(100vh-80px)] bg-[#1A1E23]">
-        <div className="pt-16 text-white flex flex-col gap-2">
+      { isSideBar && <div className="sm:min-h-[calc(100vh-80px)] bg-[#1A1E23]">
+        <div className="flex text-white justify-around sm:pt-16 gap-2 sm:flex-col ">
           <div className={`flex items-center h-16 gap-2 cursor-pointer hover:text-[#2448C7]  ${item === "trending" && "bg-black text-[#2448C7]"} p-4 px-6`} onClick={() => itemSearch("trending")}>
-            <IoHomeOutline size={ isSideBar ? `1.2rem` : `1.6rem`} />
-            {isSideBar && <p className="text-lg">Trending</p>}
+            <IoHomeOutline size={`1.6rem`} />
+            {isSideBar && <p className="hidden text-lg sm:block">Trending</p>}
           </div>
           <div className={`flex items-center h-16 gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7] ${item === "discover" && "bg-black text-[#2448C7]"}`} onClick={() => itemSearch("trending")}>
-            <IoWalletOutline size={ isSideBar ? `1.2rem` : `1.6rem`} />
-            {isSideBar && <p className="text-lg">Discover</p>}
+            <IoWalletOutline size={`1.6rem`} />
+            <p className="hidden text-lg sm:block">Discover</p>
           </div>
           <div className={`flex items-center h-16 gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7] ${item === "upcoming" && "bg-black text-[#2448C7]"}`} onClick={() => itemSearch("upcoming")}>
-            <FiCoffee size={ isSideBar ? `1.2rem` : `1.6rem`} />
-            {isSideBar && <p className="text-lg">Upcoming</p>}
+            <FiCoffee size={`1.6rem`} />
+            <p className="hidden text-lg sm:block">Upcoming</p>
           </div>
           <div className="flex items-center h-16 gap-2 cursor-pointer p-4 px-6 hover:text-[#2448C7]">
-            <FaRegHeart size={ isSideBar ? `1.2rem` : `1.6rem`} />
-            {isSideBar && <p className="text-lg">Favorite</p>}
+            <FaRegHeart size={`1.6rem`} />
+            <p className="hidden text-lg sm:block">Favorite</p>
           </div>
         </div>
         {
           isSideBar &&
-        <div className="p-6 text-zinc-400">
+        <div className="hidden p-6 text-zinc-400 sm:block">
           <h4 className="font-semibold uppercase">Genre</h4>
           <div className="mt-4 flex flex-col gap-2">
           <a href="#">Action</a>
@@ -50,7 +50,7 @@ const SideBar = () => {
           </div>
         </div>
         }
-      </div>
+      </div>}
     </nav>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 
 /* custom */
 .sidebar{
-    height: calc(100vh - 80px);
+    min-height: calc(100vh - 80px);
 }
 input:focus{outline: none;}
 .wrapper_card:hover > :not(:hover){

--- a/src/index.css
+++ b/src/index.css
@@ -5,9 +5,6 @@
 *{ font-family: "Poppins", serif;}
 
 /* custom */
-.sidebar{
-    min-height: calc(100vh - 80px);
-}
 input:focus{outline: none;}
 .wrapper_card:hover > :not(:hover){
     filter: blur(1px);


### PR DESCRIPTION
A few improvements to make the site responsive on different screens:

### Main section
- Main section is now a grid with auto-fit, so extra columns will appear on bigger screens
- Card images now have a fixed aspect ratio to prevent distorting them

### Sidebar
- Header is now sticked to the top on mobile
- Icons have been given a fixed size to prevent layout shifts and shrinking
- Fixed sidebar not stretching to account for overflow
- On mobile, `isSidebar` state now hides/shows the entire navbar, to save space
- On desktop, `isSidebar` behaves the same as before

### Other
- Important elements have been given semantic HTML tags to improve SEO
- User theme is now detected automatically; it can still be changed with the search bar togle