### PR TITLE
Nav tweaks

### DIFF
--- a/src/components/CardContainer.jsx
+++ b/src/components/CardContainer.jsx
@@ -32,7 +32,7 @@ const CardContainer = () => {
       :
       <div className='p-8'>
       <h1 className='font-semibold text-3xl text-zinc-600 dark:text-zinc-400'>{itemQuery.slice(0,1).toUpperCase()+itemQuery.slice(1)}</h1>
-      <div className='wrapper_card max-w-100 grid auto-rows-max grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] gap-5 mt-12 justify-start items-start h-[70vh]'>
+      <div className='wrapper_card max-w-100 grid auto-rows-max grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-5 mt-12 justify-start items-start h-[70vh]'>
         { moviesData.length > 0 && moviesData.map((item, index) => <Card content={item} key={index}/>)}
       </div>
     </div> 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -47,15 +47,16 @@ const SearchBar = () => {
     setIsDarkMode(!isDarkMode);
   };
   return (
-    <div className="bg-[#3B54D4] py-7 px-9 flex gap-3 justify-between items-center">
-      <search className="flex gap-3">
-        <span className="text-zinc-300">
+    <div className="bg-[#3B54D4] py-2 px-3 flex gap-3 justify-between items-center z-50 fixed w-full sm:static">
+      <search className="flex gap-5">
+        <label htmlFor="search-input" className="text-zinc-300 self-center py-5 pl-6">
           <CiSearch size="1.4rem" />
-        </span>
+        </label>
         <input
+          id="search-input"
           type="text"
           placeholder="Search..."
-          className="bg-transparent text-zinc-300 font-normal w-full"
+          className="bg-transparent text-zinc-300 font-normal w-full py-5"
           spellCheck={false}
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
@@ -63,15 +64,13 @@ const SearchBar = () => {
           ref={inputRef}
         />
       </search>
-      <div>
-        <span className="cursor-pointer text-zinc-300" onClick={toggleDarkMode}>
-          {
-            isDarkMode ?
-            <IoSunnyOutline size="1.4rem" />:
-            <FaRegMoon size="1.2rem" />
-          }
-        </span>
-      </div>
+      <button className="flex-none cursor-pointer text-zinc-300 py-5 px-6 align-center" onClick={toggleDarkMode}>
+        {
+          isDarkMode ?
+          <IoSunnyOutline size="1.4rem" />:
+          <FaRegMoon size="1.2rem" />
+        }
+      </button>
     </div>
   );
 };

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -19,7 +19,7 @@ const SideBar = () => {
   return (
     <nav className='transition duration-150 ease-out lg:w-[15%] xl:w-[12%]'>
       <Header isSideBar={isSideBar} setIsSideBar={setIsSideBar} />
-    {isSideBar &&   <div className="sm:min-h-[calc(100vh-80px)] bg-[#1A1E23] mx-4 mb-2 fixed bottom-0 rounded-[12px] w-[95vw] sm:w-[auto] z-[9] sm:static sm:m-0 sm:rounded-[0px] overflow-hidden">
+    {isSideBar &&   <div className="sm:min-h-[calc(100vh-80px)] bg-[#1A1E23] mb-2 fixed bottom-0 inset-x-3 rounded-[12px] sm:w-[auto] z-[9] sm:static sm:m-0 sm:rounded-[0px] overflow-hidden">
         <div className="flex text-white justify-around sm:pt-16 gap-2 sm:flex-col ">
           <div className={`flex items-center h-16 gap-2 cursor-pointer hover:text-[#2448C7]  ${item === "trending" && "bg-black text-[#2448C7]"} p-4 px-6`} onClick={() => itemSearch("trending")}>
             <IoHomeOutline size={`1.6rem`} />


### PR DESCRIPTION
A few minor tweaks to the look and feel of the nav bar and the search bar.

### Search bar
- Now fixed at the top on mobile
- Interactive elements have extra padding to make them easier to click
- Search input now expands to occupy all remaning space. Again, makes it bigger and easier to click
- Elements have been given semantic html tags to help interactivity.  Lens icon is now a label for the search bar, and theme toggle is now a button.

### Nav bar
- Fixed issue where it wasn't *quite* centered on mobile

### Other
- Tweaked the grid for movie cards. Now, on most small screens, it will be 2 cars wide instead of one

### To-do:
- [ ] It would be nice to hide the search bar and nav bar when scrolling down on mobile. Would save a lot of room on small screens, but I don't know enough React to do this myself :(
- [ ] Add a formatter and reconfigure eslint to make contributions more consistent. But that's the maintainer's call!
